### PR TITLE
Fix frame when system status bar is hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ VolumeBar is fully documented [here](http://gizmosachin.github.io/VolumeBar/docs
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
-pod 'VolumeBar', '~> 3.0'
+pod 'VolumeBar', '~> 3.0.1'
 ```
 
 ### [Carthage](https://github.com/Carthage/Carthage)

--- a/Sources/Internal/VolumeBarWindow.swift
+++ b/Sources/Internal/VolumeBarWindow.swift
@@ -42,6 +42,7 @@ internal final class VolumeBarWindow: UIWindow {
 		systemVolumeView.isHidden = false
 		systemVolumeView.clipsToBounds = true
 		systemVolumeView.showsRouteButton = false
+		systemVolumeView.alpha = 0.0001
 		
 		super.init(frame: .zero)
 		
@@ -77,7 +78,8 @@ internal extension VolumeBarWindow {
 		
 		// Set window frame
 		let windowOrigin = CGPoint.zero
-		var windowSize = CGSize(width: UIApplication.shared.statusBarFrame.width, height: systemEdgeInsets.top + style.edgeInsets.top + style.height + style.edgeInsets.bottom)
+		var windowSize = CGSize(width: UIScreen.main.bounds.width, height: systemEdgeInsets.top + style.edgeInsets.top + style.height + style.edgeInsets.bottom)
+		windowSize.width = max(windowSize.width, UIApplication.shared.statusBarFrame.width)
 		windowSize.height = max(windowSize.height, UIApplication.shared.statusBarFrame.height)
 		frame = CGRect(origin: windowOrigin, size: windowSize)
 		

--- a/Sources/Internal/VolumeBarWindow.swift
+++ b/Sources/Internal/VolumeBarWindow.swift
@@ -77,16 +77,18 @@ internal extension VolumeBarWindow {
 		}
 		
 		// Set window frame
-		let windowOrigin = CGPoint.zero
-		var windowSize = CGSize(width: UIScreen.main.bounds.width, height: systemEdgeInsets.top + style.edgeInsets.top + style.height + style.edgeInsets.bottom)
-		windowSize.width = max(windowSize.width, UIApplication.shared.statusBarFrame.width)
-		windowSize.height = max(windowSize.height, UIApplication.shared.statusBarFrame.height)
-		frame = CGRect(origin: windowOrigin, size: windowSize)
+		let windowX = CGFloat(0)
+		let windowY = CGFloat(0)
+		let windowWidth = abs(max(UIScreen.main.bounds.width, UIApplication.shared.statusBarFrame.width))
+		let windowHeight = abs(max(systemEdgeInsets.top + style.edgeInsets.top + style.height + style.edgeInsets.bottom, UIApplication.shared.statusBarFrame.height))
+		frame = CGRect(x: windowX, y: windowY, width: windowWidth, height: windowHeight)
 		
 		// Set view frame
-		let viewOrigin = CGPoint(x: systemEdgeInsets.left + style.edgeInsets.left, y: systemEdgeInsets.top + style.edgeInsets.top)
-		let viewSize = CGSize(width: windowSize.width - windowOrigin.x - viewOrigin.x - (systemEdgeInsets.right + style.edgeInsets.right), height: style.height)
-		viewController.view.frame = CGRect(origin: viewOrigin, size: viewSize)
+		let viewX = abs(systemEdgeInsets.left + style.edgeInsets.left)
+		let viewY = abs(systemEdgeInsets.top + style.edgeInsets.top)
+		let viewWidth = abs(windowWidth - windowX - viewX - (systemEdgeInsets.right + style.edgeInsets.right))
+		let viewHeight = abs(style.height)
+		viewController.view.frame = CGRect(x: viewX, y: viewY, width: viewWidth, height: viewHeight)
 	}
 }
 

--- a/VolumeBar.podspec
+++ b/VolumeBar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'VolumeBar'
-  s.version = '3.0'
+  s.version = '3.0.1'
   s.summary = 'A volume indicator that doesn\'t obstruct content.'
   s.homepage = 'http://github.com/gizmosachin/VolumeBar'
   s.license = 'MIT'


### PR DESCRIPTION
When the system status bar is hidden, `UIApplication.shared.statusBarFrame` returns a zero frame.

VolumeBar sets the internal frame of its window and view when `start` is called. Since it previously used `UIApplication.shared.statusBarFrame`, which could be zero when `start` is called, this could cause an incorrect layout. Now we use `UIScreen.main.bounds` instead (and wrap all layout parameters in `abs` just in case).

We can't use `UIApplication.shared.keyWindow?.bounds` because the VolumeBar might be started before the key window is available. Note that the use of `UIScreen.main.bounds` won't work on iPad in split-screen, but VolumeBar doesn't currently work on iPad at all.