### PR TITLE
#19: Only set SystemVolumeManager as the audio session observer once

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ VolumeBar is fully documented [here](http://gizmosachin.github.io/VolumeBar/).
 source 'https://github.com/CocoaPods/Specs.git'
 use_frameworks!
 
-pod 'VolumeBar', '~> 3.0.1'
+pod 'VolumeBar', '~> 3.0.2'
 ```
 
 ### [Carthage](https://github.com/Carthage/Carthage)

--- a/VolumeBar.podspec
+++ b/VolumeBar.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'VolumeBar'
-  s.version = '3.0.1'
+  s.version = '3.0.2'
   s.summary = 'A volume indicator that doesn\'t obstruct content.'
   s.homepage = 'http://github.com/gizmosachin/VolumeBar'
   s.license = 'MIT'


### PR DESCRIPTION
In edge cases, we could add the `SystemVolumeManager` as the observer of `AVAudioSession.sharedInstance().outputVolume` twice.

Since KVO retains the `SystemVolumeManager` each time `addObserver` was called, we were being retained twice and only calling `removeObserver` once. Since we `nil` out the `systemVolumeManager` in `VolumeBar` when `stop()` is called, the containing app would crash with `EXC_BAD_ACCESS` when the output volume of the device changed (since the `systemVolumeManager` observing the system volume was `nil`).