### PR TITLE
Made customStyle a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ volumeBar.start()
 Customize appearance attributes (see [`VolumeBarStyle`](http://gizmosachin.github.io/VolumeBar/Structs/VolumeBarStyle.html)):
 ```swift
 let volumeBar = VolumeBar.shared
-let customStyle = VolumeBarStyle.likeInstagram
+var customStyle = VolumeBarStyle.likeInstagram
 customStyle.trackTintColor = .white
 customStyle.trackTintColor = .darkGray
 customStyle.backgroundColor = .black


### PR DESCRIPTION
customStyle needs to be a variable because in this example because it is changed. When pasted into Xcode, it tells you to change it to var.